### PR TITLE
added additional filetypes to the scrapper allowed types

### DIFF
--- a/scrapper/scrapper/settings.py
+++ b/scrapper/scrapper/settings.py
@@ -103,7 +103,13 @@ ITEM_PIPELINES = {
 
 # Set settings whose default value is deprecated to a future-proof value
 FEED_EXPORT_ENCODING = "utf-8"
-ALLOWED_FILETYPES = os.environ.get('SUPPORTED_TYPES', '.html,.docx,.doc,.pdf,.md,.txt,.pptx').split(',')
+ALLOWED_FILETYPES = [
+    filetype.strip().lower()
+    for filetype in os.environ.get(
+        'SUPPORTED_TYPES', '.html,.docx,.doc,.pdf,.md,.txt,.pptx'
+    ).split(',')
+    if filetype.strip()
+]
 SCRAPED_DIRECTORY = os.environ.get('SCRAPED_DIRECTORY', "/scrapped-data")
 RUUTER_INTERNAL = os.environ.get('RUUTER_INTERNAL', "http://ruuter-internal:8089")
 DOWNLOAD_DELAY = 0.2

--- a/scrapper/scrapper/settings.py
+++ b/scrapper/scrapper/settings.py
@@ -103,7 +103,7 @@ ITEM_PIPELINES = {
 
 # Set settings whose default value is deprecated to a future-proof value
 FEED_EXPORT_ENCODING = "utf-8"
-ALLOWED_FILETYPES = os.environ.get('SUPPORTED_TYPES', '.html,.docx,.doc,.pdf').split(',')
+ALLOWED_FILETYPES = os.environ.get('SUPPORTED_TYPES', '.html,.docx,.doc,.pdf,.md,.txt,.pptx').split(',')
 SCRAPED_DIRECTORY = os.environ.get('SCRAPED_DIRECTORY', "/scrapped-data")
 RUUTER_INTERNAL = os.environ.get('RUUTER_INTERNAL', "http://ruuter-internal:8089")
 DOWNLOAD_DELAY = 0.2


### PR DESCRIPTION
Three places need updates. I have added update to the settings.py
1. GUI/src/pages/UploadedFiles/index.tsx
The <FileUploader> has acceptedTypes=".pdf,.doc,.docx,.html,.htm". The .md, .txt, and .pptx extensions are missing, so the frontend rejects them before upload. Note: Agency.tsx already has all three types — this page was just out of sync.

2. scrapper/scrapper/settings.py
ALLOWED_FILETYPES defaults to '.html,.docx,.doc,.pdf'. After a file is uploaded to S3 and the scrapper downloads it, SpecifiedPagesSpider checks the file extension against this list and immediately marks the file failed if it's not allowed. .md, .txt, and .pptx need to be added. The backend clean_file_task already handles all three via unstructured, so no cleaning logic changes are needed.

3. GUI/src/services/s3.ts
Both createSourceWithFiles and createSourceWithFilesForExistingSource use file.type || 'application/octet-stream' as the content type. Most browsers return an empty file.type for .md files, so they get uploaded to S3 as application/octet-stream. When the scrapper downloads them back, Python's mimetypes.guess_extension('application/octet-stream') returns .bin, which fails the allowlist check even after fix #2. The fix is to derive the content type from the file extension when file.type is empty (.md → text/markdown, .txt → text/plain, .pptx → application/vnd.openxmlformats-officedocument.presentationml.presentation). The same fallback should be applied to the Content-Type header in uploadFileToS3.