### PR TITLE
Optmizing cleaning service image

### DIFF
--- a/cleaning/Dockerfile
+++ b/cleaning/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN mkdir /scrapped-data
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY . .
 

--- a/cleaning/Dockerfile
+++ b/cleaning/Dockerfile
@@ -1,13 +1,18 @@
-FROM python:3.13 AS build
+FROM python:3.13-slim AS build
 
-RUN apt-get update && apt-get install ffmpeg libreoffice poppler-utils tesseract-ocr \
-                                      tesseract-ocr-est tesseract-ocr-rus -y
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        libreoffice \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 RUN mkdir /scrapped-data
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/cleaning/requirements.txt
+++ b/cleaning/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.115.12
 uvicorn==0.34.2
-unstructured[pdf,docx,doc,pptx,md]==0.18.5
+unstructured[docx,doc,pptx,md]==0.18.5
 pydantic-settings==2.10.1
 beautifulsoup4==4.13.4
 langdetect==1.0.9


### PR DESCRIPTION
The PDF cleaning path uses pymupdf4llm directly, so the unstructured[pdf] extras were dead weight — they were dragging in CUDA libs, GPU PyTorch, Triton, transformers, onnxruntime and OpenCV (~5GB on disk) that nothing in the codebase imports. Drop the [pdf] extras and switch the base image to python:3.13-slim. Remove tesseract/poppler/ffmpeg from apt since OCR and video extraction aren't used; libreoffice stays because .doc files need soffice to convert to .docx.

Tested end-to-end through /clean_file for html (+ image extraction), pdf, docx, doc, pptx, md and txt — all clean successfully.