### PR TITLE
Cleaning: dedicated .txt / .md flow

### DIFF
--- a/cleaning/worker/tasks.py
+++ b/cleaning/worker/tasks.py
@@ -349,6 +349,19 @@ def clean_any_file(entity: EntityToClean) -> str:
     return _elements_to_markdown(partitioned)
 
 
+def clean_plain_text(entity: EntityToClean) -> str:
+    """
+    Read a plain-text file (.txt / .md) as UTF-8 and return its contents.
+
+    No extraction is performed — the file *is* the text. Whitespace
+    normalisation is applied by the caller via normalize_newlines().
+    Invalid bytes are replaced rather than raising so a single bad byte
+    in a long file doesn't kill the whole job.
+    """
+    with entity.file_path.open("r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
 # ---------------------------------------------------------------------------
 # Image extraction
 # ---------------------------------------------------------------------------
@@ -668,6 +681,9 @@ def clean_file_task(entity: EntityToClean) -> None:
             logger.info(
                 f"Cleaned as PPTX (unstructured) for {entity.file_path.as_posix()}"
             )
+        elif file_type in (".txt", ".md"):
+            cleaned_text = clean_plain_text(entity)
+            logger.info(f"Cleaned as plain text for {entity.file_path.as_posix()}")
         else:
             cleaned_text = clean_any_file(entity)
             logger.info(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -454,6 +454,99 @@ class TestSetUpLogging:
 
 
 # ---------------------------------------------------------------------------
+# Plain-text routing (.txt, .md)
+# ---------------------------------------------------------------------------
+
+
+class TestPlainTextRouting:
+    """
+    .txt and .md files must bypass unstructured.partition() and read the
+    file verbatim. Previously they fell through to clean_any_file(), which
+    treats each line as a Title element and produces useless output —
+    especially for files where the content happens to be HTML markup.
+    """
+
+    def test_clean_plain_text_returns_file_contents_verbatim(
+        self, tmp_path: Path
+    ) -> None:
+        from worker.tasks import clean_plain_text
+
+        body = "First line.\nSecond line.\n\nThird paragraph after blank line.\n"
+        entity = _make_entity(tmp_path, ".txt", body)
+
+        assert clean_plain_text(entity) == body
+
+    def test_clean_plain_text_replaces_invalid_utf8(self, tmp_path: Path) -> None:
+        from worker.tasks import clean_plain_text
+
+        source = tmp_path / "source.txt"
+        source.write_bytes(b"good bytes \xff\xfe bad bytes ok\n")
+        meta = tmp_path / "source.meta.json"
+        meta.write_text(json.dumps({"file_type": ".txt", "metadata": {}}))
+
+        entity = MagicMock()
+        entity.file_path = source
+        entity.meta_data_path = meta
+        entity.directory_path = tmp_path
+        entity.use_llm = False
+
+        out = clean_plain_text(entity)
+        assert "good bytes" in out
+        assert "bad bytes ok" in out
+
+    def test_txt_routes_to_plain_text_not_unstructured(self, tmp_path: Path) -> None:
+        """
+        clean_file_task with file_type=".txt" must call clean_plain_text
+        and must NOT call clean_any_file (which would invoke unstructured).
+        """
+        from worker.tasks import clean_file_task
+
+        body = "Some real text content for a .txt source.\n"
+        entity = _make_entity(tmp_path, ".txt", body, use_llm=False)
+
+        with (
+            patch("worker.tasks.requests.post") as mock_post,
+            patch("worker.tasks.cleanup_directory"),
+            patch("worker.tasks.clean_any_file") as mock_any,
+        ):
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {"response": "http://mock/file"}
+            mock_resp.raise_for_status.return_value = None
+            mock_post.return_value = mock_resp
+
+            clean_file_task(entity)
+
+        assert mock_any.call_count == 0, (
+            ".txt must not be routed through clean_any_file()"
+        )
+        cleaned = (tmp_path / "cleaned.txt").read_text()
+        assert "Some real text content" in cleaned
+
+    def test_md_routes_to_plain_text(self, tmp_path: Path) -> None:
+        from worker.tasks import clean_file_task
+
+        body = "# Heading\n\nParagraph with **bold** text.\n"
+        entity = _make_entity(tmp_path, ".md", body, use_llm=False)
+
+        with (
+            patch("worker.tasks.requests.post") as mock_post,
+            patch("worker.tasks.cleanup_directory"),
+            patch("worker.tasks.clean_any_file") as mock_any,
+        ):
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {"response": "http://mock/file"}
+            mock_resp.raise_for_status.return_value = None
+            mock_post.return_value = mock_resp
+
+            clean_file_task(entity)
+
+        assert mock_any.call_count == 0
+        cleaned = (tmp_path / "cleaned.txt").read_text()
+        assert "# Heading" in cleaned
+        assert "**bold**" in cleaned
+
+
+# ---------------------------------------------------------------------------
 # Metadata mutation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -482,7 +482,9 @@ class TestPlainTextRouting:
         source = tmp_path / "source.txt"
         source.write_bytes(b"good bytes \xff\xfe bad bytes ok\n")
         meta = tmp_path / "source.meta.json"
-        meta.write_text(json.dumps({"file_type": ".txt", "metadata": {}}))
+        meta.write_text(
+            json.dumps({"file_type": ".txt", "metadata": {}}), encoding="utf-8"
+        )
 
         entity = MagicMock()
         entity.file_path = source
@@ -519,7 +521,7 @@ class TestPlainTextRouting:
         assert mock_any.call_count == 0, (
             ".txt must not be routed through clean_any_file()"
         )
-        cleaned = (tmp_path / "cleaned.txt").read_text()
+        cleaned = (tmp_path / "cleaned.txt").read_text(encoding="utf-8")
         assert "Some real text content" in cleaned
 
     def test_md_routes_to_plain_text(self, tmp_path: Path) -> None:
@@ -541,7 +543,7 @@ class TestPlainTextRouting:
             clean_file_task(entity)
 
         assert mock_any.call_count == 0
-        cleaned = (tmp_path / "cleaned.txt").read_text()
+        cleaned = (tmp_path / "cleaned.txt").read_text(encoding="utf-8")
         assert "# Heading" in cleaned
         assert "**bold**" in cleaned
 


### PR DESCRIPTION
Plain-text inputs previously fell through to clean_any_file(), which calls unstructured.partition() and treats each line as a Title element. For real .txt content the output is noisy and pointless; for HTML mistakenly saved as .txt the output is the raw markup wrapped as "titles" — neither is useful.

Add clean_plain_text() that just reads the file as UTF-8 with errors="replace" and returns the contents verbatim. The existing normalize_newlines() pass collapses whitespace at the call site, so we don't need any extraction step for formats that are already plain text.

Route .txt and .md to the new helper. Other extensions still go through unstructured / pymupdf / trafilatura as before.

Tests cover:
- reading contents verbatim
- bad UTF-8 bytes don't crash
- .txt routes to clean_plain_text and NOT clean_any_file
- .md routes the same way